### PR TITLE
hub: reveal avatars when profile image loads

### DIFF
--- a/public_html/includes/header-hub.php
+++ b/public_html/includes/header-hub.php
@@ -5,4 +5,60 @@
   — <a href="/admin/stop-impersonation.php" style="color:#cb978a; text-decoration:underline;">Stop</a>
 </div>
 <?php endif; ?>
-<header></header>
+<header>
+  <nav class="navbar">
+    <div class="container">
+      <div class="nav-content">
+        <div class="nav-brand">
+          <img src="/assets/images/logo-graphic.png" alt="QuietGo Logo" style="width: 40px; height: 40px;" loading="lazy">
+          <div>
+            <span class="quietgo-brand">
+              <span class="quiet">Quiet</span><span class="go">Go</span>
+            </span>
+            <span class="muted" style="margin-left: 8px; font-size: 0.875rem;">Hub</span>
+          </div>
+        </div>
+
+        <div class="nav-links">
+          <a href="/hub/" class="nav-link">Dashboard</a>
+          <span id="userProfile" class="nav-profile" style="display: flex; align-items: center; gap: 12px;">
+            <img
+              id="userAvatar"
+              src=""
+              alt="Profile avatar"
+              style="width: 32px; height: 32px; border-radius: 50%; display: none;"
+            >
+            <div style="display: flex; flex-direction: column; align-items: flex-end;">
+              <span id="userName" class="muted" style="font-size: 0.875rem; font-weight: 500;"></span>
+              <span id="userSubscription" class="status-badge status-free" style="font-size: 0.625rem;">Free</span>
+            </div>
+          </span>
+          <button class="btn btn-outline" onclick="handleSignOut()">Sign Out</button>
+        </div>
+
+        <button class="mobile-menu-btn" onclick="toggleMobileMenu()">
+          <svg class="icon" viewBox="0 0 24 24">
+            <path d="M3 12h18M3 6h18M3 18h18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+          </svg>
+        </button>
+      </div>
+
+      <div class="mobile-menu" id="mobileMenu">
+        <a href="/hub/" class="nav-link">Dashboard</a>
+        <div style="padding: 16px 0; border-bottom: 1px solid var(--border-color);">
+          <div id="userProfileMobile" style="display: flex; align-items: center; gap: 12px; margin-bottom: 8px;">
+            <img
+              id="userAvatarMobile"
+              src=""
+              alt="Profile avatar"
+              style="width: 32px; height: 32px; border-radius: 50%; display: none;"
+            >
+            <span id="userNameMobile" class="muted"></span>
+          </div>
+          <span id="userSubscriptionMobile" class="status-badge status-free">Free</span>
+        </div>
+        <button class="btn btn-outline" onclick="handleSignOut()" style="margin-top: 16px;">Sign Out</button>
+      </div>
+    </div>
+  </nav>
+</header>

--- a/public_html/js/hub.js
+++ b/public_html/js/hub.js
@@ -69,10 +69,14 @@ function updateUserInfo() {
             const avatarMobile = document.getElementById('userAvatarMobile');
             if (avatar) {
                 avatar.src = userData.profileImageUrl;
+                avatar.removeAttribute('hidden');
+                avatar.hidden = false;
                 avatar.style.display = 'block';
             }
             if (avatarMobile) {
                 avatarMobile.src = userData.profileImageUrl;
+                avatarMobile.removeAttribute('hidden');
+                avatarMobile.hidden = false;
                 avatarMobile.style.display = 'block';
             }
         }


### PR DESCRIPTION
## Summary
- build out the hub header include with the dashboard navigation and profile avatar slots defaulted to `display: none`
- update the hub dashboard script to clear any `hidden` attribute before displaying profile avatars so fetched images become visible

## Testing
- php -l public_html/includes/header-hub.php
- node --input-type=module <<'NODE' … (simulates updateUserInfo with profileImageUrl)


------
https://chatgpt.com/codex/tasks/task_e_68cd8f4949ac832685ad93ad4b9a2545