### PR TITLE
public: align download ctas with store handlers

### DIFF
--- a/public_html/index.php
+++ b/public_html/index.php
@@ -159,7 +159,7 @@
               iCloud sync
             </li>
           </ul>
-          <button class="btn btn-primary" type="button" onclick="handleGetStarted()">Download on App Store</button>
+          <button class="btn btn-primary" type="button" onclick="handleAppStore()">Download on App Store</button>
         </article>
 
         <article class="card pricing-card">
@@ -190,7 +190,7 @@
               Cloud backup
             </li>
           </ul>
-          <button class="btn btn-accent" type="button" onclick="handleGetStarted()">Get it on Google Play</button>
+          <button class="btn btn-accent" type="button" onclick="handlePlayStore()">Get it on Google Play</button>
         </article>
       </div>
 


### PR DESCRIPTION
## Summary
- update the download section buttons to invoke the same App Store and Play Store handlers already used by the hero CTAs
- keep the existing analytics wrappers in `js/site.js` by continuing to route clicks through `handleAppStore()` and `handlePlayStore()`

## Mapping to Acceptance Criteria
- Quality: PHP 8.2 lint passes → `php -l public_html/index.php`

## Testing
- `php -l public_html/index.php`


------
https://chatgpt.com/codex/tasks/task_e_68cdef332e388326862d8c8cfcee4160