### PR TITLE
Restore Firebrand styling for public header and footer

### DIFF
--- a/public_html/includes/footer-public.php
+++ b/public_html/includes/footer-public.php
@@ -8,31 +8,47 @@
             <span class="quiet">Quiet</span><span class="go">Go</span>
           </span>
         </a>
-        <p class="footer-copy">Discreet digestive health tracking with AI-powered insights. Capture, connect, and act with confidence.</p>
+        <p class="footer-copy">Discreet health tracking with AI-powered insights. Plate to pattern.</p>
       </div>
+
       <div class="footer-column">
-        <h3>Explore</h3>
+        <h3>Product</h3>
         <ul>
-          <li><a href="/#features">Features</a></li>
-          <li><a href="/#download">Download</a></li>
-          <li><a href="/hub/login.php">Get Started</a></li>
+          <li><button type="button" onclick="scrollToSection('features')">Features</button></li>
+          <li><button type="button" onclick="scrollToSection('download')">Download</button></li>
+          <li><a href="/privacy.php">Privacy</a></li>
         </ul>
       </div>
+
       <div class="footer-column">
-        <h3>Company</h3>
+        <h3>Legal</h3>
         <ul>
-          <li><a href="/">Home</a></li>
-          <li><a href="mailto:hello@quietgo.com">Contact</a></li>
-          <li><a href="/privacy.php">Privacy &amp; Terms</a></li>
+          <li><a href="/privacy.php">Terms &amp; Privacy</a></li>
+          <li><button type="button" onclick="scrollToSection('privacy')">Data Protection</button></li>
+          <li><a href="/privacy.php#hipaa">HIPAA Notice</a></li>
+        </ul>
+      </div>
+
+      <div class="footer-column">
+        <h3>Support</h3>
+        <ul>
+          <li><a href="mailto:hello@quietgo.com">Contact QuietGo</a></li>
+          <li><a href="/hub/">QuietGo Hub</a></li>
+          <li><a href="/hub/login.php">Subscriber Login</a></li>
+          <li><a href="mailto:privacy@quietgo.com">Privacy Requests</a></li>
         </ul>
       </div>
     </div>
+
     <div class="footer-bottom">
+      <p>© <?php echo date('Y'); ?> QuietGo. All rights reserved.</p>
       <div class="footer-meta">
-        <span>© <?php echo date('Y'); ?> <span class="quietgo-brand"><span class="quiet">Quiet</span><span class="go">Go</span></span></span>
-        <span>Not medical advice • General wellness only</span>
+        <span>Not medical advice</span>
+        <span>•</span>
+        <span>General wellness only</span>
+        <span>•</span>
+        <a class="admin-link" href="/admin/login.php" data-testid="link-admin">Admin</a>
       </div>
-      <a class="admin-link" href="/admin/login.php" data-testid="link-admin">Admin</a>
     </div>
   </div>
 </footer>

--- a/public_html/includes/header-public.php
+++ b/public_html/includes/header-public.php
@@ -8,42 +8,42 @@
             <span class="quietgo-brand">
               <span class="quiet">Quiet</span><span class="go">Go</span>
             </span>
-            <span class="brand-subtitle">Plate to pattern</span>
+            <span class="brand-subtitle muted">Plate to pattern</span>
           </div>
         </a>
 
         <div class="nav-links" role="navigation">
-          <a href="/#features" class="nav-link">Features</a>
-          <a href="/#download" class="nav-link">Download</a>
+          <button class="nav-link" type="button" onclick="scrollToSection('features')">Features</button>
+          <button class="nav-link" type="button" onclick="scrollToSection('download')">Download</button>
           <a href="/privacy.php" class="nav-link">Privacy</a>
-          <a class="btn btn-outline" href="/hub/">
-            <span class="quietgo-brand">
+          <button class="btn btn-outline" type="button" onclick="handleLogin()">
+            <span class="quietgo-brand" style="font-size: 0.875rem;">
               <span class="quiet">Quiet</span><span class="go">Go</span>
             </span>
             <span class="btn-suffix">Hub</span>
-          </a>
-          <a class="btn btn-primary" href="/hub/login.php">Get Started</a>
+          </button>
+          <button class="btn btn-primary" type="button" onclick="handleGetStarted()">Get Started</button>
         </div>
 
         <button class="mobile-menu-btn" type="button" aria-expanded="false" aria-controls="mobileMenu" onclick="toggleMobileMenu(this)">
           <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
-            <path d="M3 12h18M3 6h18M3 18h18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+            <path d="M3 12h18M3 6h18M3 18h18" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
           </svg>
           <span class="sr-only">Toggle navigation</span>
         </button>
       </div>
 
       <div class="mobile-menu" id="mobileMenu">
-        <a href="/#features" class="nav-link">Features</a>
-        <a href="/#download" class="nav-link">Download</a>
+        <button class="nav-link" type="button" onclick="scrollToSection('features')">Features</button>
+        <button class="nav-link" type="button" onclick="scrollToSection('download')">Download</button>
         <a href="/privacy.php" class="nav-link">Privacy</a>
-        <a class="btn btn-outline" href="/hub/">
+        <button class="btn btn-outline" type="button" onclick="handleLogin()" style="margin-top: 16px;">
           <span class="quietgo-brand">
             <span class="quiet">Quiet</span><span class="go">Go</span>
           </span>
           <span class="btn-suffix">Hub</span>
-        </a>
-        <a class="btn btn-primary" href="/hub/login.php">Get Started</a>
+        </button>
+        <button class="btn btn-primary" type="button" onclick="handleGetStarted()" style="margin-top: 8px;">Get Started</button>
       </div>
     </div>
   </nav>


### PR DESCRIPTION
## Summary
- Rebuild the public header include to mirror Firebrand navigation, including CTA buttons that call the existing scroll and auth handlers while keeping canonical logo assets
- Restructure the public footer include into Firebrand’s four-column layout with updated copy, internal section buttons, and admin link styling

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cdefc497a48326b0539ad5ae0d2b63