### PR TITLE
Update forgot password button to skip validation

### DIFF
--- a/public_html/hub/login.php
+++ b/public_html/hub/login.php
@@ -1,4 +1,12 @@
-<?php if (session_status() === PHP_SESSION_NONE) { session_start(); } ?>
+<?php
+if (session_status() === PHP_SESSION_NONE) {
+  session_start();
+}
+
+$submittedAction = $_POST['action'] ?? null;
+$forgotSuccess = $_SERVER['REQUEST_METHOD'] === 'POST' && $submittedAction === 'forgot';
+$emailValue = isset($_POST['email']) ? (string) $_POST['email'] : '';
+?>
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -19,12 +27,20 @@
         <header>
           <img src="/assets/images/logo-graphic.png" alt="QuietGo logo" width="56" height="56" loading="lazy">
           <h1>Access the QuietGo Hub</h1>
-          <p>Sign in with the same email you use in the QuietGo mobile app. We’ll email you a secure one-time link to complete login.</p>
+          <p>Use the same email and password you set in the QuietGo app to sign in.</p>
         </header>
-        <form class="login-form" method="post" action="#" onsubmit="event.preventDefault(); trackButtonClick('hub_login_request'); alert('A secure sign-in link will be delivered once the integration is live.');">
+        <form class="login-form" id="hubLoginForm" method="post" action="">
           <label for="loginEmail">Email address</label>
-          <input id="loginEmail" type="email" name="email" required placeholder="you@example.com">
-          <button class="btn btn-primary btn-large" type="submit">Send sign-in link</button>
+          <input id="loginEmail" type="email" name="email" required placeholder="you@example.com" value="<?php echo htmlspecialchars($emailValue, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>">
+          <label for="loginPassword">Password</label>
+          <input id="loginPassword" type="password" name="password" required autocomplete="current-password" placeholder="Enter your password">
+          <div class="login-actions" style="display: flex; flex-wrap: wrap; gap: var(--spacing-sm); align-items: center;">
+            <button class="btn btn-primary btn-large" type="submit" name="action" value="login">Sign in</button>
+            <button class="btn btn-outline" type="submit" name="action" value="forgot" formnovalidate>Forgot password?</button>
+          </div>
+<?php if ($forgotSuccess): ?>
+          <p class="support-note" role="status" style="color: var(--accent-color); margin-top: var(--spacing-sm);">If your email is on file, we'll send password reset instructions shortly.</p>
+<?php endif; ?>
         </form>
         <p class="support-note">Need help? Email <a href="mailto:support@quietgo.com">support@quietgo.com</a> and our team will respond within one business day.</p>
       </div>
@@ -32,5 +48,26 @@
   </section>
 </main>
 <?php include __DIR__ . '/../includes/footer-hub.php'; ?>
+<script>
+  (function () {
+    const form = document.getElementById('hubLoginForm');
+    if (!form) {
+      return;
+    }
+
+    form.addEventListener('submit', function (event) {
+      const submitter = event.submitter;
+      if (submitter && submitter.name === 'action' && submitter.value === 'forgot') {
+        return;
+      }
+
+      event.preventDefault();
+      if (typeof trackButtonClick === 'function') {
+        trackButtonClick('hub_login_request');
+      }
+      alert('A secure sign-in link will be delivered once the integration is live.');
+    });
+  })();
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- preserve posted email values and flag forgot-password submissions so the template can show a confirmation message
- require a password for normal logins while adding a forgot-password submit button that bypasses HTML5 validation via `formnovalidate`
- handle login submissions with the existing client-side placeholder flow while allowing forgot-password requests to post normally

## Testing
- php -l public_html/hub/login.php

------
https://chatgpt.com/codex/tasks/task_e_68cdfd35e0d0832697559f4b0cc052cb