### PR TITLE
Allow forgot password submission without password validation

### DIFF
--- a/public_html/hub/login.php
+++ b/public_html/hub/login.php
@@ -36,7 +36,7 @@ $emailValue = isset($_POST['email']) ? (string) $_POST['email'] : '';
           <input id="loginPassword" type="password" name="password" required autocomplete="current-password" placeholder="Enter your password">
           <div class="login-actions" style="display: flex; flex-wrap: wrap; gap: var(--spacing-sm); align-items: center;">
             <button class="btn btn-primary btn-large" type="submit" name="action" value="login">Sign in</button>
-            <button class="btn btn-outline" type="submit" name="action" value="forgot" formnovalidate>Forgot password?</button>
+            <button class="btn btn-outline" type="submit" name="action" value="forgot" formnovalidate="formnovalidate">Forgot password?</button>
           </div>
 <?php if ($forgotSuccess): ?>
           <p class="support-note" role="status" style="color: var(--accent-color); margin-top: var(--spacing-sm);">If your email is on file, we'll send password reset instructions shortly.</p>


### PR DESCRIPTION
## Summary
- add an explicit formnovalidate attribute to the Forgot password? submit button so it bypasses HTML5 validation when used

## Testing
- php -S 0.0.0.0:8000 -t public_html (manual)
- curl -s -d 'email=test%40example.com&action=forgot' http://127.0.0.1:8000/hub/login.php
- php -l public_html/hub/login.php

------
https://chatgpt.com/codex/tasks/task_e_68ce0110baec8326a28a1abfc6793b2c